### PR TITLE
Handle invalid delete torrent IDs

### DIFF
--- a/del.go
+++ b/del.go
@@ -25,16 +25,22 @@ func del(tokens []string) {
 		id, err := strconv.Atoi(i)
 		if err != nil {
 			send(fmt.Sprintf("del: %s is not an ID", i), false)
-			return
+			continue
 		}
 
-		if err := rtorrent.Delete(false, torrents[id]); err != nil {
+		if id < 0 || id >= len(torrents) {
+			send(fmt.Sprintf("del: ID %d is out of range (0 <= id < %d)", id, len(torrents)), false)
+			continue
+		}
+
+		torrent := torrents[id]
+		if err := rtorrent.Delete(false, torrent); err != nil {
 			logger.Print("del:", err)
 			send("del: "+err.Error(), false)
 			continue
 		}
 
-		send(fmt.Sprintf("Deleted: %s", torrents[id].Name), false)
+		send(fmt.Sprintf("Deleted: %s", torrent.Name), false)
 
 	}
 }

--- a/deldata.go
+++ b/deldata.go
@@ -25,15 +25,21 @@ func deldata(tokens []string) {
 		id, err := strconv.Atoi(i)
 		if err != nil {
 			send(fmt.Sprintf("deldata: %s is not an ID", i), false)
-			return
+			continue
 		}
 
-		if err := rtorrent.Delete(true, torrents[id]); err != nil {
+		if id < 0 || id >= len(torrents) {
+			send(fmt.Sprintf("deldata: ID %d is out of range (0 <= id < %d)", id, len(torrents)), false)
+			continue
+		}
+
+		torrent := torrents[id]
+		if err := rtorrent.Delete(true, torrent); err != nil {
 			logger.Print("deldata:", err)
 			send("deldata: "+err.Error(), false)
 			continue
 		}
 
-		send(fmt.Sprintf("Deleted with data: %s", torrents[id].Name), false)
+		send(fmt.Sprintf("Deleted with data: %s", torrent.Name), false)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure delete commands validate torrent IDs before indexing into the list
- report parsing and bounds errors without aborting the rest of the IDs

## Testing
- go test ./... *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d0abf1d0ec8329912d988a97feb93f