### PR TITLE
Improve Telegram message chunking and add UTF-8 test

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -360,47 +361,75 @@ func main() {
 	}
 }
 
+const telegramMessageLimit = 4096
+
+func chunkMessage(text string, limit int) []string {
+	if limit <= 0 {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if utf8.RuneCountInString(text) <= limit {
+			chunks = append(chunks, text)
+			break
+		}
+
+		byteLimit := 0
+		runeCount := 0
+		for byteLimit < len(text) && runeCount < limit {
+			_, size := utf8.DecodeRuneInString(text[byteLimit:])
+			byteLimit += size
+			runeCount++
+		}
+
+		safeWindow := []byte(text[:byteLimit])
+		cut := byteLimit
+		if idx := bytes.LastIndexByte(safeWindow, '\n'); idx >= 0 {
+			cut = idx + 1
+		}
+
+		if cut == 0 {
+			_, size := utf8.DecodeRuneInString(text)
+			if size == 0 {
+				break
+			}
+			cut = size
+		}
+
+		chunks = append(chunks, text[:cut])
+		text = text[cut:]
+	}
+
+	if len(chunks) == 0 {
+		chunks = append(chunks, "")
+	}
+
+	return chunks
+}
+
 // send takes a chat id and a message to send, returns the message id of the send message
 func send(text string, markdown bool) int {
 	// set typing action
 	action := tgbotapi.NewChatAction(chatID, tgbotapi.ChatTyping)
 	Bot.Send(action)
 
-	// check the rune count, telegram is limited to 4096 chars per message;
-	// so if our message is > 4096, split it in chunks the send them.
-	msgRuneCount := utf8.RuneCountInString(text)
-LenCheck:
-	stop := 4095
-	if msgRuneCount > 4096 {
-		for text[stop] != 10 { // '\n'
-			stop--
-		}
-		msg := tgbotapi.NewMessage(chatID, text[:stop])
+	chunks := chunkMessage(text, telegramMessageLimit)
+	var resp tgbotapi.Message
+
+	for _, chunk := range chunks {
+		msg := tgbotapi.NewMessage(chatID, chunk)
 		msg.DisableWebPagePreview = true
 		if markdown {
 			msg.ParseMode = tgbotapi.ModeMarkdown
 		}
 
-		// send current chunk
-		if _, err := Bot.Send(msg); err != nil {
+		r, err := Bot.Send(msg)
+		if err != nil {
 			logger.Printf("[ERROR] Send: %s", err)
+			continue
 		}
-		// move to the next chunk
-		text = text[stop:]
-		msgRuneCount = utf8.RuneCountInString(text)
-		goto LenCheck
-	}
-
-	// if msgRuneCount < 4096, send it normally
-	msg := tgbotapi.NewMessage(chatID, text)
-	msg.DisableWebPagePreview = true
-	if markdown {
-		msg.ParseMode = tgbotapi.ModeMarkdown
-	}
-
-	resp, err := Bot.Send(msg)
-	if err != nil {
-		logger.Printf("[ERROR] Send: %s", err)
+		resp = r
 	}
 
 	return resp.MessageID

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestChunkMessageLongUTF8WithoutNewline(t *testing.T) {
+	const repeats = telegramMessageLimit*2 + 123
+
+	var builder strings.Builder
+	builder.Grow(repeats * len("你"))
+	for i := 0; i < repeats; i++ {
+		builder.WriteString("你")
+	}
+	text := builder.String()
+
+	chunks := chunkMessage(text, telegramMessageLimit)
+
+	if len(chunks) == 0 {
+		t.Fatalf("expected chunks, got none")
+	}
+
+	expectedChunks := (repeats + telegramMessageLimit - 1) / telegramMessageLimit
+	if len(chunks) != expectedChunks {
+		t.Fatalf("expected %d chunks, got %d", expectedChunks, len(chunks))
+	}
+
+	var combined strings.Builder
+	totalRunes := 0
+	for i, chunk := range chunks {
+		if !utf8.ValidString(chunk) {
+			t.Fatalf("chunk %d is not valid UTF-8", i)
+		}
+
+		runeCount := utf8.RuneCountInString(chunk)
+		if runeCount == 0 {
+			t.Fatalf("chunk %d was empty", i)
+		}
+		if runeCount > telegramMessageLimit {
+			t.Fatalf("chunk %d exceeded limit: %d", i, runeCount)
+		}
+		if i < len(chunks)-1 && runeCount != telegramMessageLimit {
+			t.Fatalf("chunk %d expected %d runes, got %d", i, telegramMessageLimit, runeCount)
+		}
+
+		combined.WriteString(chunk)
+		totalRunes += runeCount
+	}
+
+	if totalRunes != repeats {
+		t.Fatalf("expected %d runes total, got %d", repeats, totalRunes)
+	}
+
+	if combined.String() != text {
+		t.Fatalf("combined chunks do not match original text")
+	}
+}


### PR DESCRIPTION
## Summary
- split outgoing messages on the last newline before Telegram's 4096 character limit with a rune-safe fallback
- refactor send to iterate over all generated chunks
- add a unit test covering long newline-free UTF-8 messages

## Testing
- GO111MODULE=off go test ./... *(fails: missing github.com/pyed/go-humanize, github.com/pyed/rtapi, github.com/pyed/tailer, gopkg.in/telegram-bot-api.v4)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b0beb4d48329ae68f8a86a71a5fc