### PR TITLE
Fix completed torrent log notifications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/pyed/rtelegram
 go 1.24
 
 require (
-	github.com/pyed/go-humanize v0.0.0-20170228161531-259d2a102b87
-	github.com/pyed/rtapi v0.0.0-20250922191555-7e83be835be9
-	github.com/pyed/tailer v0.0.0-20190130224839-376cd2db7eb6
-	gopkg.in/telegram-bot-api.v4 v4.6.4
+        github.com/pyed/go-humanize v0.0.0-20170228161531-259d2a102b87
+        github.com/pyed/rtapi v0.0.0-20250922191555-7e83be835be9
+        gopkg.in/telegram-bot-api.v4 v4.6.4
 )
 
 require (


### PR DESCRIPTION
## Summary
- replace the tailer-based watcher with an internal log monitor that continuously reads appended entries
- trim empty updates, handle file rotation, and wait for chat registration before notifying
- remove the unused tailer module dependency from go.mod

## Testing
- go build ./... *(fails: blocked while attempting to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e1962175bc832988023f64750518dc